### PR TITLE
Add tip for playing custom sound files with Xcode breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Use `Cmd+\` to toggle a breakpoint on the current line.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
+### Play sound files in breakpoints
+
+> Audible Xcode breakpoints allow a sound effect to be played while continuing the executable without interruptions. This can be a really useful debugging tool. Custom Xcode breakpoint sound files can be found on GitHub.
+
+Example sounds: [Xcode Breakpoint Sounds](https://github.com/matthewreagan/Xcode-Breakpoint-Sounds)
+Source: [Matt Reagan](http://mattreagandev.com/?article=20170306)
+
 # [Build Times](#build-times)
 
 ### Fix slow codesigning

--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xco
 
 ### Play sound files in breakpoints
 
-> Audible Xcode breakpoints allow a sound effect to be played while continuing the executable without interruptions. This can be a really useful debugging tool. Custom Xcode breakpoint sound files can be found on GitHub.
+> Audible Xcode breakpoints allow a sound effect to be played while continuing the executable without interruptions. This can be a really useful debugging tool. Custom Xcode breakpoint sound files can be found on GitHub at [Xcode Breakpoint Sounds](https://github.com/matthewreagan/Xcode-Breakpoint-Sounds).
 
-Example sounds: [Xcode Breakpoint Sounds](https://github.com/matthewreagan/Xcode-Breakpoint-Sounds)
 Source: [Matt Reagan](http://mattreagandev.com/?article=20170306)
 
 # [Build Times](#build-times)


### PR DESCRIPTION
Add a tip for sound file playback with Xcode breakpoints. This includes a link to an example sound file collection hosted on GitHub, and the original article. Blog post is a bit dated but this is a technique I still use continually, and the custom sound files linked are usually a better choice than the default system alert sounds.