### PR TITLE
Use Apple glyphs for Cmd, Alt, Ctrl and Shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Source: [Jesse Squires](https://www.jessesquires.com/blog/2020/01/21/xcode-tip-b
 
 ### Quickly toggling breakpoints
 
-Use `⌘\` to toggle a breakpoint on the current line.
+Use **&#8984; \\** to toggle a breakpoint on the current line.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
@@ -79,8 +79,7 @@ Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xco
 
 ### Apply all fix-its
 
-Go to the Editor menu and choose Fix All Issues to apply fix-its all at once. 
-**Keyboard shortcut**: `⌃⌥⌘F`
+Go to the Editor menu and choose Fix All Issues (**&#8963;&#8997;&#8984; F**) to apply fix-its all at once 
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
@@ -102,7 +101,7 @@ Source: [Michael Tsai](https://mjtsai.com/blog/2018/03/27/nsdoublelocalizedstrin
 
 ### Viewing .crash files
 
-In Xcode’s Organizer, in the Crashes section, you can right-click or `⌃`-click on any row and choose Show in Finder. This will reveal a .crashpoint file — do a Show Package Contents and then dig in further. You will find .crash files with the full crash logs, which provide a lot more info than what you see in Organizer.
+In Xcode’s Organizer, in the Crashes section, you can right-click or &#8963;`-click on any row and choose Show in Finder. This will reveal a .crashpoint file — do a Show Package Contents and then dig in further. You will find .crash files with the full crash logs, which provide a lot more info than what you see in Organizer.
 
 Source: [Brent Simmons](https://inessential.com/2021/03/16/the_hottest_of_all_xcode_tips)
 
@@ -149,8 +148,8 @@ Source: [Ole Begemann](https://oleb.net/blog/2017/07/xcode-9-text-macros/)
 ### Improving the assistant editor
 
 1. Set “Uses Focused Editor” in the Navigation preferences
-1. `⌘J` to switch between panes or open new ones
-1. `⌘⇧O` to open files in the currently focused pane
+1. **&#8984;J** to switch between panes or open new ones
+1. **&#8984;&#8679;O** to open files in the currently focused pane
 
 Source: [Jesse Squires](https://www.jessesquires.com/blog/2018/06/12/xcode-tip-improving-assistant-editor/)
 
@@ -164,33 +163,33 @@ Source: [Jesse Squires](https://www.jessesquires.com/blog/2018/07/01/xcode-tip-d
 
 ### Jump to a specific line
 
-Open the file you want. Press `⌘L`, type a line number and Xcode will jump directly to that line.
+Open the file you want. Press &#8984;L`, type a line number and Xcode will jump directly to that line.
 
 ### Reindenting/Formatting code
 
-Press `⌃I` to apply Xcode's indentation and formatting.
+Press **&#8963;I** to apply Xcode's indentation and formatting.
 
 ### Adding comments quickly
 
-Use `⌘/` to toggle comments for the current line or selection. Use `⌥⌘/`, pressed directly before a method to have Xcode generate a documentation comment.
+Use **&#8984;/** to toggle comments for the current line or selection. Use **&#8997;&#8984;/**, pressed directly before a method to have Xcode generate a documentation comment.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
 ### Jump to file in source navigator
 
-Press `⌘⇧J` to quickly jump to the current open file in the navigator to easily see and select related files.
+Press **&#8984;&#8679;J** to quickly jump to the current open file in the navigator to easily see and select related files.
 
 Source: [Jeroen Leenarts](https://leenarts.net/2020/02/18/frequently-used-keyboard-shortcuts-i-use-inwith-xcode/)
 
 ### Open the jump bar
 
-Press `⌃6` to open the symbol jump bar in Xcode. Now start typing. Try it, jumping to a function in the current file, never has been so easy.
+Press **&#8963;6** to open the symbol jump bar in Xcode. Now start typing. Try it, jumping to a function in the current file, never has been so easy.
 
 Source: [Jeroen Leenarts](https://leenarts.net/2020/02/18/frequently-used-keyboard-shortcuts-i-use-inwith-xcode/)
 
 ###  Remapping unhelpful keys
 
-Some great shortcuts (e.g. `⇧⌘O` for Open Quickly) are next to useless shortcuts (`⇧⌘P`, for the never times you want to print code.) It takes only seconds to remove unhelpful keys, and you can even remap things like `⌘P` to resuming SwiftUI's preview.
+Some great shortcuts (e.g. **&#8679;&#8984;O** for Open Quickly) are next to useless shortcuts (**&#8679;&#8984;P**, for the never times you want to print code.) It takes only seconds to remove unhelpful keys, and you can even remap things like **&#8984;P** to resuming SwiftUI's preview.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
@@ -212,7 +211,7 @@ Source: [Jesse Squires](https://www.jessesquires.com/blog/2020/04/13/fully-autom
 
 ### Re-run your last test
 
-Use `⌃⌥⌘G` to re-run your last test. [Jon Reid](https://twitter.com/qcoding) has a name for this making it easier to remember: “smash go!”
+Use **&#8963;&#8997;&#8984;G** to re-run your last test. [Jon Reid](https://twitter.com/qcoding) has a name for this making it easier to remember: “smash go!”
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
@@ -244,7 +243,7 @@ Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xco
 
 ### Generating an interface file
 
-Press `⌃⌘↑` to display a generated interface, showing properties, function signatures, and comments for a type. Press it again, to jump to tests for that file if they exist.
+Press **&#8963;&#8984;&#8679;** to display a generated interface, showing properties, function signatures, and comments for a type. Press it again, to jump to tests for that file if they exist.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xco
 
 ### Apply all fix-its
 
-Go to the Editor menu and choose Fix All Issues to apply fix-its all at once.
+Go to the Editor menu and choose Fix All Issues to apply fix-its all at once. 
+**Keyboard shortcut**: `⌃⌥⌘F`
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Source: [Jesse Squires](https://www.jessesquires.com/blog/2020/01/21/xcode-tip-b
 
 ### Quickly toggling breakpoints
 
-Use `Cmd+\` to toggle a breakpoint on the current line.
+Use `⌘\` to toggle a breakpoint on the current line.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
@@ -102,7 +102,7 @@ Source: [Michael Tsai](https://mjtsai.com/blog/2018/03/27/nsdoublelocalizedstrin
 
 ### Viewing .crash files
 
-In Xcode’s Organizer, in the Crashes section, you can right-click or ctrl-click on any row and choose Show in Finder. This will reveal a .crashpoint file — do a Show Package Contents and then dig in further. You will find .crash files with the full crash logs, which provide a lot more info than what you see in Organizer.
+In Xcode’s Organizer, in the Crashes section, you can right-click or `⌃`-click on any row and choose Show in Finder. This will reveal a .crashpoint file — do a Show Package Contents and then dig in further. You will find .crash files with the full crash logs, which provide a lot more info than what you see in Organizer.
 
 Source: [Brent Simmons](https://inessential.com/2021/03/16/the_hottest_of_all_xcode_tips)
 
@@ -149,8 +149,8 @@ Source: [Ole Begemann](https://oleb.net/blog/2017/07/xcode-9-text-macros/)
 ### Improving the assistant editor
 
 1. Set “Uses Focused Editor” in the Navigation preferences
-1. `cmd-J` to switch between panes or open new ones
-1. `cmd-shift-O` to open files in the currently focused pane
+1. `⌘J` to switch between panes or open new ones
+1. `⌘⇧O` to open files in the currently focused pane
 
 Source: [Jesse Squires](https://www.jessesquires.com/blog/2018/06/12/xcode-tip-improving-assistant-editor/)
 
@@ -164,33 +164,33 @@ Source: [Jesse Squires](https://www.jessesquires.com/blog/2018/07/01/xcode-tip-d
 
 ### Jump to a specific line
 
-Open the file you want. Press `Cmd+L`, type a line number and Xcode will jump directly to that line.
+Open the file you want. Press `⌘L`, type a line number and Xcode will jump directly to that line.
 
 ### Reindenting/Formatting code
 
-Press `Ctrl+I` to apply Xcode's indentation and formatting.
+Press `⌃I` to apply Xcode's indentation and formatting.
 
 ### Adding comments quickly
 
-Use `Cmd+/` to toggle comments for the current line or selection. Use `Option+Cmd+/`, pressed directly before a method to have Xcode generate a documentation comment.
+Use `⌘/` to toggle comments for the current line or selection. Use `⌥⌘/`, pressed directly before a method to have Xcode generate a documentation comment.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
 ### Jump to file in source navigator
 
-Press `Cmd+Shift+J` to quickly jump to the current open file in the navigator to easily see and select related files.
+Press `⌘⇧J` to quickly jump to the current open file in the navigator to easily see and select related files.
 
 Source: [Jeroen Leenarts](https://leenarts.net/2020/02/18/frequently-used-keyboard-shortcuts-i-use-inwith-xcode/)
 
 ### Open the jump bar
 
-Press `Ctrl+6` to open the symbol jump bar in Xcode. Now start typing. Try it, jumping to a function in the current file, never has been so easy.
+Press `⌃6` to open the symbol jump bar in Xcode. Now start typing. Try it, jumping to a function in the current file, never has been so easy.
 
 Source: [Jeroen Leenarts](https://leenarts.net/2020/02/18/frequently-used-keyboard-shortcuts-i-use-inwith-xcode/)
 
 ###  Remapping unhelpful keys
 
-Some great shortcuts (e.g. `Shift+Cmd+O` for Open Quickly) are next to useless shortcuts (`Shift+Cmd+P`, for the never times you want to print code.) It takes only seconds to remove unhelpful keys, and you can even remap things like `Cmd+P` to resuming SwiftUI's preview.
+Some great shortcuts (e.g. `⇧⌘O` for Open Quickly) are next to useless shortcuts (`⇧⌘P`, for the never times you want to print code.) It takes only seconds to remove unhelpful keys, and you can even remap things like `⌘P` to resuming SwiftUI's preview.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
@@ -212,7 +212,7 @@ Source: [Jesse Squires](https://www.jessesquires.com/blog/2020/04/13/fully-autom
 
 ### Re-run your last test
 
-Use `Ctrl+Opt+Cmd+G` to re-run your last test. [Jon Reid](https://twitter.com/qcoding) has a name for this making it easier to remember: “smash go!”
+Use `⌃⌥⌘G` to re-run your last test. [Jon Reid](https://twitter.com/qcoding) has a name for this making it easier to remember: “smash go!”
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 
@@ -244,7 +244,7 @@ Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xco
 
 ### Generating an interface file
 
-Press `Ctrl+Cmd+Up` to display a generated interface, showing properties, function signatures, and comments for a type. Press it again, to jump to tests for that file if they exist.
+Press `⌃⌘↑` to display a generated interface, showing properties, function signatures, and comments for a type. Press it again, to jump to tests for that file if they exist.
 
 Source: [Paul Hudson](https://www.hackingwithswift.com/articles/229/24-quick-xcode-tips)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 Folks in the Apple developer community are always sharing great Xcode tips &mdash; usually via Twitter or blog posts. Wouldn't it be nice if we collected them all in a single place to share? The goal of this project is to host all of these Xcode tips in a single place, and make it [easy for anyone to contribute](https://github.com/Xcode-Tips/xcode-tips.github.io/blob/main/.github/CONTRIBUTING.md).
 
+#### Quick reference for Apple glyphs HTML codes
+
+| Symbol name | Glyph | HTML code |
+| --------| :---: | :---: |
+| Command | &#8984; | \&#8984; |
+| Alt | &#8997; | \&#8997; |
+| Control | &#8963; | \&#8963; |
+| Shift | &#8679; | \&#8679; |
+
 # Contents
 
 - [Breakpoints](#breakpoints)


### PR DESCRIPTION
In this PR:

- added keyboard shortcut for fix-its hint
- replace all Cmd/Alt/Ctrl/Shift with apple glyphs ⌘ ⌥ ⌃ ⇧
